### PR TITLE
make sure latest scene is never in the future (#12)

### DIFF
--- a/eodal_basetiffs/utils.py
+++ b/eodal_basetiffs/utils.py
@@ -171,6 +171,9 @@ def set_latest_scene(
     :param timestamp:
         time stamp of the latest scene
     """
+    # make sure the latest scene is never in the future
+    if timestamp > datetime.now():
+        timestamp = datetime.now()
     with open(output_dir.joinpath('latest_scene'), 'w+') as f:
         f.write(f'{timestamp.date()}')
 


### PR DESCRIPTION
Check in `set_latest_scene` that the date passed is not in the future and if so set it to the value of `datetime.now`